### PR TITLE
Multiplatform support inc. Windows; some cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ PREFIX ?= /usr/local
 PROJECT = tldr
 
 all:
-	$(CC) $(CFLAGS) -O2 $(LDFLAGS) $(PROJECT).c -o $(PROJECT)
+	$(CC) $(CFLAGS) -O2 $(PROJECT).c -o $(PROJECT) $(LDFLAGS)
 
 debug:
-	$(CC) $(CFLAGS) $(LDFLAGS) -g $(PROJECT).c -o $(PROJECT)
+	$(CC) $(CFLAGS) -g $(PROJECT).c -o $(PROJECT) $(LDFLAGS)
 
 gdb: debug
 	gdb ./$(PROJECT)

--- a/config.h
+++ b/config.h
@@ -3,28 +3,25 @@
 /* URL to download man pages. */
 static const char *PAGES_URL = "https://codeload.github.com/tldr-pages/tldr/zip/master";
 
-/* Path to temporary store the downloaded archive with pages. */
-static const char *PAGES_TMP = "/tmp/tldr_pages.zip";
-
 /* Path to store man pages relative to $HOME. */
 static const char *PAGES_PATH = "/.config/tldr";
 
 /* Pages language, uncomment ONE of the following. */
-static const char *PAGES_LANG = "/pages"; /* English */
-/* static const char *PAGES_LANG = "/pages.de"; */
-/* static const char *PAGES_LANG = "/pages.es"; */
-/* static const char *PAGES_LANG = "/pages.fr"; */
-/* static const char *PAGES_LANG = "/pages.hbs"; */
-/* static const char *PAGES_LANG = "/pages.it"; */
-/* static const char *PAGES_LANG = "/pages.ja"; */
-/* static const char *PAGES_LANG = "/pages.ko"; */
-/* static const char *PAGES_LANG = "/pages.pt_BR"; */
-/* static const char *PAGES_LANG = "/pages.pt_PT"; */
-/* static const char *PAGES_LANG = "/pages.ta"; */
-/* static const char *PAGES_LANG = "/pages.zh"; */
+static const char *PAGES_LANG = "/pages";              /*  English */
+/* static const char *PAGES_LANG = "/pages.de"; */     /*   German */
+/* static const char *PAGES_LANG = "/pages.es"; */     /*  Spanish */
+/* static const char *PAGES_LANG = "/pages.fr"; */     /*   French */
+/* static const char *PAGES_LANG = "/pages.hbs"; */    /* Serbo-Croatian */
+/* static const char *PAGES_LANG = "/pages.it"; */     /*  Italian */
+/* static const char *PAGES_LANG = "/pages.ja"; */     /* Japanese */
+/* static const char *PAGES_LANG = "/pages.ko"; */     /*   Korean */
+/* static const char *PAGES_LANG = "/pages.pt_BR"; */  /* Portuguese: BR */
+/* static const char *PAGES_LANG = "/pages.pt_PT"; */  /* Portuguese: PT */
+/* static const char *PAGES_LANG = "/pages.ta"; */     /*   Tamil  */ 
+/* static const char *PAGES_LANG = "/pages.zh"; */     /*  Chinese */
 
 /* Colors and styling. */
 static const char *HEADING_STYLE = "\033[31m";
-static const char *SUBHEADING_STYLE = "\033[4m";
+static const char *SUBHEADING_STYLE = "\033[22;4m";
 static const char *COMMAND_DESC_STYLE = "\033[22;32m";
 static const char *COMMAND_STYLE = "\033[1m";


### PR DESCRIPTION
Hi there,
I've been messing around with this since you released it--really wonderful how straightforward it is. I've managed to make a portable static build, too, at least for Windows, but want to make that code a bit nicer (this minimally involves changing the Makefile and possibly involves a configuration script). I have tried in the meantime to adhere to the code style per the readme. The other changes I've made are printing-related, and while I like the results, the code is not as elegant as your one liners, and there are a few other things I'd like to try there, too. 
In any case, this commit does a few things (though it isn't actually very long):
-It allows for untldr to build and run on Windows via mingw64 (so gcc, tested both 32- and 64-bit flavors) as well as in the Cygwin environment (this time, I only tested for a 64-bit target, and anyway 32-bit Cygwin will soon be unsupported, so long-term that might get hairy), and makes some changes to console output mode specific to it; without doing this, ANSI/VT100 codes will either not be interpreted at all (in the regular Windows ConHost) or will be interpreted inconsistently (by the wonderful Windows Terminal app, and also by mintty). These changes are otherwise minor (like adding a 'clear line from where the cursor is' command to RESET_STYLING, without which some styles, such as underlines, get displayed over empty space, right up until the next printf() statement, unfortunately), and do not cause issues for other platforms, and each change for Windows' sake was marked as such in the code. (Probably the most egregious of these was the need to explicitly invoke writing in binary mode, without which random CRLFs are chucked into the downloaded zip, corrupting it). 
--I did not mark the one change I had to make in the Makefile for this to work, namely, moving $(LDFLAGS) to the end of the `all` and `debug` commands, without which those libraries won't be found. 
-To run on platforms other than Linux, the dependency upon Linux's limits.h has been replaced with a generic `<limits.h>` include; this works on Windows (again at least via `gcc`, I have not tried `clang`, vs/ucrt, or any other C compiler on Windows), Debian Buster (gcc) and FreeBSD 12 (for this I installed `gcc`, but FreeBSD's default make uses clang, and I *think* that's what got used). I had initially had a long ifdef referring to the specific `limits.h` each platform used (see: https://arto.s3.amazonaws.com/notes/posix ) but simply using the generic one (presumably, part of the compiler's standard library) seemed like a more elegant solution. That said, leaving it out entirely has no effect on compilation and does not appear to affect performance, so that could be an option too--I'm not sure which constants from this file you wanted? I also pointed this out in more concise form in a comment, fwiw.
-Makes changes to the zip file's name and location. I wasn't sure why both the name and path of the temporary zip file were something easily configurable by the user. The zip file's name is of no real consequence given that it's not useful beyond the initial fetch (to this end, at end of decompression, I added a line deleting it entirely). The default "/tmp" in that case is  also a sane default only on *nix platforms where that path exists (yes, it's supposed to) and the user has not changed what the temporary directory is. (C:\tmp does not exist by default on Windows and attempting to write to it will error out if it isn't found.) So, I removed this configuration option from config.h and wrote a few lines querying the environment as to where the temporary directory was, using the common variable names for such a path on each platform, with"/tmp" as a failsafe--it is a POSIX standard after all.
-Renames a couple of variables in extract_pages() to make what they are a bit clearer (to me, anyway). 
-Fixes a typo ("Failer")
Hopefully, this is acceptable. I would rather contribute to this little project than maintain a fork. 
-Eli