### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,7 +1,7 @@
 /* See LICENSE file for copyright and license details. */
 
 /* URL to download man pages. */
-static const char *PAGES_URL = "https://codeload.github.com/tldr-pages/tldr/zip/master";
+static const char *PAGES_URL = "https://codeload.github.com/tldr-pages/tldr/zip/main";
 
 /* Path to store man pages relative to $HOME. */
 static const char *PAGES_PATH = "/.config/tldr";


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).