### PR TITLE
Fix pathname inside tldr_pages.zip

### DIFF
--- a/tldr.c
+++ b/tldr.c
@@ -152,7 +152,7 @@ extract_pages(void)
 		    archive_error_string(ap));
 
 	/* A place inside the archive to extract pages from. */
-	strcpy(src_path, "tldr-master");
+	strcpy(src_path, "tldr-main");
 	strcat(src_path, PAGES_LANG);
 	strcat(src_path, "/");
 


### PR DESCRIPTION
Running "tldr -u" resulted in:
$ tldr -u
Fetching pages...
Extracting pages...
Segmentation fault

Renaming "tldr-master" to "tldr-main" in the source code to match the zip archive fixes the problem: $ ./tldr -u
Fetching pages...
Extracting pages...
Indexing pages...